### PR TITLE
Fix typo in command title from "Clear OAuth Cache" to "Clear OAuth2 C…

### DIFF
--- a/src/vscode-extension/package.json
+++ b/src/vscode-extension/package.json
@@ -70,7 +70,7 @@
       },
       {
         "command": "rq.clearOAuthCache",
-        "title": "Clear OAuth Cache",
+        "title": "Clear OAuth2 Cache",
         "category": "RQ"
       },
       {


### PR DESCRIPTION
…ache"